### PR TITLE
Add new Docker Hub Python Script

### DIFF
--- a/scripts/codecov-requirements.txt
+++ b/scripts/codecov-requirements.txt
@@ -8,3 +8,4 @@ pytest==8.3.2
 pytest-cov==5.0.0
 tomli==2.0.1
 PyGithub
+pytest_mock

--- a/scripts/docker_hub_tags.py
+++ b/scripts/docker_hub_tags.py
@@ -1,0 +1,42 @@
+import requests
+import argparse
+import json
+
+def get_tags(repository, image_name):
+
+    if repository is None or image_name is None:
+        raise TypeError("Repository name and image name must not be None")
+
+    url = f'https://hub.docker.com/v2/repositories/{repository}/{image_name}/tags?page_size=10&order_by=last_updated'
+    response = requests.get(url)
+    if response.status_code == 200:
+        tags = response.json()['results']
+        output = [
+            {
+                'name': tag['name'],
+                'status': tag['tag_status'],
+                'last_pushed': tag['tag_last_pushed']
+            }
+            for tag in tags
+        ]
+
+        return output
+    else:
+        print(f"Failed to fetch tags: {response.status_code}")
+        return []
+
+if __name__ == '__main__':
+
+    # USAGE
+    # python docker-hub-tags.py -r <repository> -i <image_name>
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-r', '--repository', type=str, required=True, help='Repository name')
+    parser.add_argument('-i', '--image_name', type=str, required=True, help='Image name')
+    args = parser.parse_args()
+
+    repository = args.repository
+    image_name = args.image_name
+
+    tags = get_tags(repository, image_name)
+    print(json.dumps(tags, indent=4))

--- a/scripts/tests/test_docker_hub_tags.py
+++ b/scripts/tests/test_docker_hub_tags.py
@@ -1,0 +1,60 @@
+import pytest
+import requests
+import json
+from pytest_mock import mocker
+
+# Small workaround to use absolute imports
+import sys
+from pathlib import Path # if you haven't already done so
+file = Path(__file__).resolve()
+parent, root = file.parent, file.parents[1]
+sys.path.append(str(root))
+
+# Additionally remove the current file's directory from sys.path
+try:
+    sys.path.remove(str(parent))
+except ValueError: # Already removed
+    pass
+
+from docker_hub_tags import get_tags
+
+class MockResponse:
+    def __init__(self, status_code, json_data=None):
+        self.status_code = status_code
+        self.json_data = json_data
+
+    def json(self):
+        return self.json_data
+
+def test_get_tags_success(mocker):
+    # Mock the requests.get function to return a successful response
+    mocker.patch('requests.get', return_value=MockResponse(200, {'results': [{'name': 'test', 'tag_status': 'active', 'tag_last_pushed': '2023-02-20T14:30:00.000Z'}]}))
+
+    # Call the get_tags function
+    tags = get_tags('test_repository', 'test_image')
+
+    # Assert that the function returns the expected result
+    assert len(tags) == 1
+    assert tags[0]['name'] == 'test'
+    assert tags[0]['status'] == 'active'
+    assert tags[0]['last_pushed'] == '2023-02-20T14:30:00.000Z'
+
+def test_get_tags_failure(mocker):
+    # Mock the requests.get function to return a failed response
+    mocker.patch('requests.get', return_value=MockResponse(404))
+
+    # Call the get_tags function
+    tags = get_tags('test_repository', 'test_image')
+
+    # Assert that the function returns an empty list
+    assert tags == []
+
+def test_get_tags_invalid_repository():
+    # Call the get_tags function with an invalid repository name
+    with pytest.raises(TypeError):
+        get_tags(None, 'test_image')
+
+def test_get_tags_invalid_image():
+    # Call the get_tags function with an invalid image name
+    with pytest.raises(TypeError):
+        get_tags('test_repository', None)


### PR DESCRIPTION
Add new script to get last 10 tags from Docker Hub for a given image name and repo name.

Usage:

python3 docker-hub-tags.py -r <repository> -i <image_name>