### PR TITLE
Improve CI/CD workflows and update README

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,54 +9,44 @@ permissions:
 
 jobs:
   check-dockerfile-changes:
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-
     outputs:
       affected_folder: ${{ steps.affected-folder.outputs.AFFECTED_FOLDER }}
       image_name_folder: ${{ steps.affected-folder.outputs.IMAGE_NAME_FOLDER }}
+      dockerfile_changed: ${{ steps.affected-folder.outputs.DOCKERFILE_CHANGED }}
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3.5.2
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v2.1.0
+      uses: actions/checkout@v4
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        fetch-depth: 0
 
     - name: Determine affected folder
       id: affected-folder
       run: |
-        git remote update
-        git fetch
-        AFFECTED_FOLDER=$(git diff --name-only origin/main..origin/${{ github.head_ref }} | grep -i 'Dockerfile' | xargs -I {} dirname {} | sort -u)
-        IMAGE_NAME_FOLDER=$(git diff --name-only origin/main..origin/${{ github.head_ref }} | grep -i 'Dockerfile' | xargs -I {} dirname {} | sort -u | awk -F/ '{print $(NF-0)}')
-        echo "AFFECTED_FOLDER=$AFFECTED_FOLDER" >> $GITHUB_OUTPUT
-        echo "IMAGE_NAME_FOLDER=$IMAGE_NAME_FOLDER" >> $GITHUB_OUTPUT
-        echo "Affected folders: $AFFECTED_FOLDER"
-        echo "Image name folder: $IMAGE_NAME_FOLDER"
+        git fetch origin main
+        CHANGED_DOCKERFILE=$(git diff --name-only origin/main...HEAD | grep -i 'Dockerfile' | head -1)
 
-        echo "IMAGE_NAME_ARTIFACT=$IMAGE_NAME_FOLDER" > image_name.txt
-
-        if [[ $AFFECTED_FOLDER == '' ]]; then
+        if [[ -z "$CHANGED_DOCKERFILE" ]]; then
           echo "========= No Dockerfile affected on this PR ========="
+          echo "DOCKERFILE_CHANGED=false" >> $GITHUB_OUTPUT
           exit 0
         fi
-    
-    - name: Set Repo Name
-      id: repo-name
-      run: |
-        echo "REPO=natandias1" >> $GITHUB_OUTPUT
-    
-  
+
+        AFFECTED_FOLDER=$(dirname "$CHANGED_DOCKERFILE")
+        IMAGE_NAME_FOLDER=$(basename "$AFFECTED_FOLDER")
+
+        echo "AFFECTED_FOLDER=$AFFECTED_FOLDER" >> $GITHUB_OUTPUT
+        echo "IMAGE_NAME_FOLDER=$IMAGE_NAME_FOLDER" >> $GITHUB_OUTPUT
+        echo "DOCKERFILE_CHANGED=true" >> $GITHUB_OUTPUT
+        echo "Affected folder: $AFFECTED_FOLDER"
+        echo "Image name folder: $IMAGE_NAME_FOLDER"
+
   build-and-push:
     needs: check-dockerfile-changes
-    if: ${{ github.event_name == 'pull_request' && needs.check-dockerfile-changes.outputs.AFFECTED_FOLDER != '' }}
+    if: ${{ needs.check-dockerfile-changes.outputs.dockerfile_changed == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,42 +54,33 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2.1.0
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Set Repo Name
-      id: repo-name
+    - name: Compute Dockerfile hash
+      id: dockerfile-hash
       run: |
-        echo "REPO=natandias1" >> $GITHUB_ENV
+        DOCKERFILE_PATH=$(find "${{ needs.check-dockerfile-changes.outputs.affected_folder }}" -maxdepth 1 -iname 'Dockerfile' | head -1)
+        DOCKERFILE_HASH=$(sha256sum "$DOCKERFILE_PATH" | awk '{print $1}' | cut -c1-12)
+        echo "DOCKERFILE_PATH=$DOCKERFILE_PATH" >> $GITHUB_OUTPUT
+        echo "DOCKERFILE_HASH=$DOCKERFILE_HASH" >> $GITHUB_OUTPUT
+        echo "Dockerfile: $DOCKERFILE_PATH"
+        echo "Hash: $DOCKERFILE_HASH"
 
-    - name: Docker Metadata action
-      id: meta
-      uses: docker/metadata-action@v4.4.0
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
       with:
-        images: ${{ env.REPO }}/${{ needs.check-dockerfile-changes.outputs.IMAGE_NAME_FOLDER }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=pr
-        flavor: |
-          latest=false
-    
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v5.3.0
-      with:
-        file: ${{ needs.check-dockerfile-changes.outputs.AFFECTED_FOLDER }}/Dockerfile
+        file: ${{ steps.dockerfile-hash.outputs.DOCKERFILE_PATH }}
         context: .
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        push: ${{ github.event_name == 'pull_request' }}
-    
-    - name: Check status
-      run: | 
-        echo "Dockerfile check complete"
-        echo "Docker image name: ${{ needs.check-dockerfile-changes.outputs.IMAGE_NAME_FOLDER }}"
-        echo "Affected folders: ${{ needs.check-dockerfile-changes.outputs.AFFECTED_FOLDER }}"
-        echo "Docker image tags: ${{ steps.meta.outputs.tags }}"
+        tags: natandias1/${{ needs.check-dockerfile-changes.outputs.image_name_folder }}:${{ steps.dockerfile-hash.outputs.DOCKERFILE_HASH }}
+        push: true
+
+    - name: Summary
+      run: |
+        echo "Build complete"
+        echo "Image: natandias1/${{ needs.check-dockerfile-changes.outputs.image_name_folder }}:${{ steps.dockerfile-hash.outputs.DOCKERFILE_HASH }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     branches:
       - main
-    tags: [ 'v*' ]
     inputs:
-      folder: 
+      folder:
         description: 'Dockerfile folder location'
         required: true
         type: string
@@ -18,45 +17,8 @@ on:
         default: 'latest'
 
 jobs:
-  set-envs:
-    name: Set Environment Variables
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      
-    outputs:
-      lastReleaseTag: ${{ steps.get_last_release_tag.outputs.lastReleaseTag }}
-      IMAGE_NAME_FOLDER: ${{ steps.set-image-name.outputs.IMAGE_NAME_FOLDER }}
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3.5.2
-    
-    - name: "Set image name folder"
-      id: set-image-name
-      run: | 
-        IMAGE_NAME_FOLDER=$(awk -F "/" '{print $NF}' <<< ${{ github.event.inputs.folder }})
-        echo "IMAGE_NAME_FOLDER=$IMAGE_NAME_FOLDER" >> $GITHUB_OUTPUT
-        echo "Image name folder: $IMAGE_NAME_FOLDER"
-    
-    - name: Get Last release tag
-      uses: actions/github-script@v3
-      id: get_last_release_tag
-      with:
-        script: |
-          const { data: releases } = await github.repos.listReleases({
-            owner: context.repo.owner,
-            repo: context.repo.repo
-          });
-
-          const lastReleaseTag = releases[0].tag_name;
-          core.setOutput('lastReleaseTag', lastReleaseTag);
-
-          console.log(`Last release tag: ${lastReleaseTag}`);
-
-  build-docker-image-and-push:
+  build-and-release:
     name: Build and Push Docker Image
-    needs: set-envs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,21 +26,42 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3.5.2
-    
+      uses: actions/checkout@v4
+
+    - name: Set image name
+      id: set-image-name
+      run: |
+        FOLDER="${{ github.event.inputs.folder }}"
+        IMAGE_NAME_FOLDER=$(basename "${FOLDER%/}")
+        echo "IMAGE_NAME_FOLDER=$IMAGE_NAME_FOLDER" >> $GITHUB_OUTPUT
+        echo "Image name: $IMAGE_NAME_FOLDER"
+
+    - name: Find Dockerfile
+      id: find-dockerfile
+      run: |
+        DOCKERFILE_PATH=$(find "${{ github.event.inputs.folder }}" -maxdepth 1 -iname 'Dockerfile' | head -1)
+        if [[ -z "$DOCKERFILE_PATH" ]]; then
+          echo "No Dockerfile found in ${{ github.event.inputs.folder }}"
+          exit 1
+        fi
+        echo "DOCKERFILE_PATH=$DOCKERFILE_PATH" >> $GITHUB_OUTPUT
+        echo "Dockerfile: $DOCKERFILE_PATH"
+
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2.1.0
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Set Repo Name
-      id: repo-name
-      run: |
-        echo "REPO=natandias1" >> $GITHUB_ENV
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        file: ${{ steps.find-dockerfile.outputs.DOCKERFILE_PATH }}
+        context: .
+        tags: natandias1/${{ steps.set-image-name.outputs.IMAGE_NAME_FOLDER }}:${{ github.event.inputs.release_tag }}
+        push: true
 
-    - name: Build and Push Docker Image
-      id: build-and-push
+    - name: Summary
       run: |
-        docker build -t ${{ env.REPO }}/${{ needs.set-envs.outputs.IMAGE_NAME_FOLDER }}:${{ needs.set-envs.outputs.lastReleaseTag }} -f ${{ github.event.inputs.folder }}/Dockerfile .
-        docker push ${{ env.REPO }}/${{ needs.set-envs.outputs.IMAGE_NAME_FOLDER }}:${{ needs.set-envs.outputs.lastReleaseTag }}
+        echo "Release complete"
+        echo "Image: natandias1/${{ steps.set-image-name.outputs.IMAGE_NAME_FOLDER }}:${{ github.event.inputs.release_tag }}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,69 @@
-[![CI](https://github.com/natan-dias/my-devops-repo/actions/workflows/ci.yaml/badge.svg)](https://github.com/natan-dias/my-devops-repo/actions/workflows/ci.yaml) [![Release Image to Docker Hub](https://github.com/natan-dias/my-devops-repo/actions/workflows/release.yml/badge.svg)](https://github.com/natan-dias/my-devops-repo/actions/workflows/release.yml) [![codecov](https://codecov.io/gh/natan-dias/my-devops-repo/graph/badge.svg?token=GSHQHG9UAD)](https://codecov.io/gh/natan-dias/my-devops-repo) 
+[![CI](https://github.com/natan-dias/my-devops-repo/actions/workflows/ci.yaml/badge.svg)](https://github.com/natan-dias/my-devops-repo/actions/workflows/ci.yaml) [![Release Image to Docker Hub](https://github.com/natan-dias/my-devops-repo/actions/workflows/release.yml/badge.svg)](https://github.com/natan-dias/my-devops-repo/actions/workflows/release.yml) [![codecov](https://codecov.io/gh/natan-dias/my-devops-repo/graph/badge.svg?token=GSHQHG9UAD)](https://codecov.io/gh/natan-dias/my-devops-repo)
 
 # my-devops-repo
 
-## Devops Repo for testing
+A personal DevOps repository for building, deploying, and managing containerized applications on Kubernetes. Includes CI/CD automation, Docker image definitions, Kubernetes infrastructure manifests, and application code.
 
-- Small test for auto PR review bot
+## Repository Structure
+
+```
+.
+├── .github/workflows/   # GitHub Actions CI/CD pipelines
+├── apps/                # Application source code
+├── argocd-deploys/      # ArgoCD Application manifests
+├── images/              # Docker image definitions
+├── infra/               # Kubernetes infrastructure manifests (Kustomize)
+└── scripts/             # Automation and utility scripts
+```
+
+## Workflows
+
+| Workflow | Trigger | Description |
+|---|---|---|
+| **CI** | Pull Request → `main` | Detects Dockerfile changes, builds the image, and pushes it to Docker Hub tagged with the Dockerfile content hash |
+| **Release** | Manual (`workflow_dispatch`) | Builds and pushes a Docker image to Docker Hub with a specified release tag |
+| **Codecov** | Pull Request | Runs test suite and uploads coverage report to Codecov |
+| **PR Auto-Approval** | Pull Request | Auto-approves PRs opened by the repository owner |
+
+## Applications (`apps/`)
+
+| App | Description |
+|---|---|
+| `basic-python-api` | Minimal Python HTTP API |
+| `basic-video-store-api-with-db` | Flask API with SQLite, simulating a video store |
+| `kb-api` | Knowledge Base REST API — manages commands and notes in a structured database |
+
+## Docker Images (`images/`)
+
+| Image | Base | Description |
+|---|---|---|
+| `spark-base` | `openjdk:11.0.11-jre-slim-buster` | Apache Spark 3.5.1 base image (master/worker) |
+| `spark-executor` | `natandias1/spark-base` | Spark executor for Kubernetes |
+| `webserver-example` | `nginx:latest` | Nginx server serving a sample web page |
+| `sql-database` | `mysql:9.3.0` | MySQL database with environment-based configuration |
+
+## Infrastructure (`infra/`)
+
+| Stack | Tool | Description |
+|---|---|---|
+| `argocd` | Kustomize | ArgoCD GitOps controller |
+| `hashicorp-vault` | Kustomize + Helm | HashiCorp Vault for secrets management |
+| `redis` | Kustomize | Redis in-memory cache |
+| `spark` | Kustomize | Apache Spark cluster on Kubernetes |
+| `webserver-example` | Kustomize | Nginx ingress example |
+| `knowledge-base-app` | Kubernetes | PostgreSQL deployment for the KB API |
+
+## ArgoCD Applications (`argocd-deploys/`)
+
+ArgoCD Application definitions that sync the `infra/` manifests to the cluster:
+- `argo-redis` — deploys `infra/redis`
+- `argo-spark` — deploys `infra/spark/overlay/spark-base`
+
+## Scripts (`scripts/`)
+
+| Script | Description |
+|---|---|
+| `build_and_push.py` | Builds and pushes a Docker image by folder name |
+| `docker_hub_tags.py` | Lists Docker Hub image tags for a repository |
+| `python_auto_pr_approve.py` | Approves PRs via GitHub API |
+| `kustomize_build_filters.py` | Utility for Kustomize operations |


### PR DESCRIPTION
- CI: tag dev images with Dockerfile SHA256 hash instead of branch/PR refs
- CI: remove unnecessary Docker login from detection job
- CI: fix git diff to use three-dot syntax and fetch-depth: 0
- CI: add dockerfile_changed output for clean job condition
- CI: update actions to checkout@v4, login-action@v3, build-push-action@v6
- Release: collapse to single job, removing GitHub API release tag lookup
- Release: wire release_tag input as actual Docker tag
- Release: use find -iname for case-insensitive Dockerfile lookup
- README: rewrite with full structure, workflow, and component tables