### PR TITLE
Fix Codecov reports to measure actual source code coverage instead of…

### DIFF
--- a/.github/workflows/codecov-workflow.yaml
+++ b/.github/workflows/codecov-workflow.yaml
@@ -1,6 +1,10 @@
 name: Codecov Workflow
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
… test files.

- Correct --cov path to point at scripts/ source files instead of scripts/tests/
- Add setup.cfg to configure pytest and coverage omit rules
- Add missing tests for kustomize_build_filters.py and fix test_build_image to mock subprocess
- Trigger Codecov workflow on push to main so the badge reflects the merged baseline
- Raise coverage target to 80%